### PR TITLE
Added python3-docker to support Ansible modules for Docker container …

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -4,6 +4,7 @@ RUN apt-get update \
     && apt-get dist-upgrade -y \
     && apt-get install -y build-essential make g++ libssl-dev libffi-dev \
     && apt-get install -y sshpass \
+    && apt-get install -y python3-docker \
     && pip install --upgrade pip \
     && pip install --upgrade ansible \
     && pip install --upgrade docker-compose \


### PR DESCRIPTION
…lifecycle tasks

Ernest - thanks for putting this original Docker image together. I use it on my Pi environment.

The role on Ansible galaxy for installing Docker that seems to be widely used is geerlingguy.docker_arm and this requires the python3-docker to be present. This is the motivation for adding it to your image.

Thanks for your consideration!